### PR TITLE
SysUI: Fix reporting of swipe progess in notification panel

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/SwipeHelper.java
+++ b/packages/SystemUI/src/com/android/systemui/SwipeHelper.java
@@ -91,6 +91,8 @@ public class SwipeHelper implements Gefingerpoken {
     private int mFalsingThreshold;
     private boolean mTouchAboveFalsingThreshold;
 
+    private float mSwipeProgressFadeEnd;
+
     public SwipeHelper(int swipeDirection, Callback callback, Context context) {
         mCallback = callback;
         mHandler = new Handler();
@@ -110,6 +112,7 @@ public class SwipeHelper implements Gefingerpoken {
         } else {
             mSwipeZone = SWIPE_ZONE_TOP | SWIPE_ZONE_BOTTOM;
         }
+        mSwipeProgressFadeEnd = SWIPE_PROGRESS_FADE_END;
     }
 
     public SwipeHelper(int swipeDirection, int swipeZone, Callback callback, Context context) {
@@ -184,7 +187,7 @@ public class SwipeHelper implements Gefingerpoken {
 
     private float getSwipeProgressForOffset(View view) {
         float viewSize = getSize(view);
-        final float fadeSize = SWIPE_PROGRESS_FADE_END * viewSize;
+        final float fadeSize = mSwipeProgressFadeEnd * viewSize;
         float result = 1.0f;
         float pos = getTranslation(view);
         if (pos >= viewSize * SWIPE_PROGRESS_FADE_START) {
@@ -514,6 +517,10 @@ public class SwipeHelper implements Gefingerpoken {
                 break;
         }
         return true;
+    }
+
+    public void setSwipeProgressFadeEnd(float end) {
+        mSwipeProgressFadeEnd = end;
     }
 
     private int getFalsingThreshold() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -379,6 +379,7 @@ public class NotificationPanelView extends PanelView implements
 
         mSwipeHelper = new SwipeHelper(SwipeHelper.X,
                 SwipeHelper.SWIPE_ZONE_LEFT, mSwipeCallback, mContext);
+        mSwipeHelper.setSwipeProgressFadeEnd(1.0f);
         mMinimumFlingVelocity = ViewConfiguration.get(getContext())
                 .getScaledMinimumFlingVelocity();
 


### PR DESCRIPTION
SwipHelper only uses half of the child views width for determining
swip progress.  This patch adds a new member variable that can be
changed via a setter.  The default is the constant value that was
used prior to this patch so that it does not affect notifications
that also use the SwipeHelper.

Change-Id: Ie19ab812bed2248dbc842294a8dc4b5f6520efb8
TICKET: CYNGNOS-2485
